### PR TITLE
refactor: use native imports for handlers and commands

### DIFF
--- a/src/core/CommandHandler.js
+++ b/src/core/CommandHandler.js
@@ -1,6 +1,6 @@
-import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import Commands from "./imports/CommandsIndex.js"
 
 export class CommandHandler {
     constructor(bot) {
@@ -10,10 +10,8 @@ export class CommandHandler {
     }
 
     async init () {
-        const files = fs.readdirSync(this.commandsPath).filter(file => file.endsWith('.js'));
 
-        for (const file of files) {
-            const command = await import(`file://${path.join(this.commandsPath, file)}`);
+        for (const command of Commands) {
             if (command.default?.name && command.default?.execute) {
                 this.commands.set(command.default.name, command.default);
             }

--- a/src/core/PacketHandler.js
+++ b/src/core/PacketHandler.js
@@ -1,6 +1,6 @@
-import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import Handlers from "./imports/HandlersIndex.js"
 
 export class PacketHandler {
     constructor(bot) {
@@ -10,10 +10,8 @@ export class PacketHandler {
     }
 
     async init () {
-        const files = fs.readdirSync(this.handlersPath).filter(file => file.endsWith('.js'));
 
-        for (const file of files) {
-            const handler = await import(`file://${path.join(this.handlersPath, file)}`);
+        for (const handler of Handlers) {
             if (handler.default?.name && handler.default?.execute) {
                 this.handlers.set(handler.default.name, handler.default);
             }

--- a/src/core/imports/CommandsIndex.js
+++ b/src/core/imports/CommandsIndex.js
@@ -1,0 +1,39 @@
+import AvatarCommand from AvatarCommand.js
+import CharCommand from CharCommand.js
+import ClearCommand from ClearCommand.js
+import CommandsCommand from "CommandsCommand.js"
+import HomeCommand from "HomeCommand.js"
+import IdCommand from "IdCommand.js"
+import InfoCommand from "InfoCommand.js"
+import NickCommand from "NickCommand.js"
+import PcbackCommand from "PcbackCommand.js"
+import PingCommand from "PingCommand.js"
+import PstyleCommand from "PstyleCommand.js"
+import RegCommand from "RegCommand.js"
+import RestartCommand from "RestartCommand.js"
+import SayCommand from "SayCommand.js"
+import StatusCommand from "StatusCommand.js"
+import StealthCommand from "StealthCommand.js"
+import WelcomeMsgCommand from "WelcomeMsgCommand.js"
+import WelcomeTypeCommand from "WelcomeTypeCommand.js"
+
+export default [
+    AvatarCommand,
+    CharCommand,
+    ClearCommand,
+    CommandsCommand,
+    HomeCommand,
+    IdCommand,
+    InfoCommand,
+    NickCommand,
+    PcbackCommand,
+    PingCommand,
+    PstyleCommand,
+    RegCommand,
+    RestartCommand,
+    SayCommand,
+    StatusCommand,
+    StealthCommand,
+    WelcomeMsgCommand,
+    WelcomeTypeCommand
+]

--- a/src/core/imports/HandlersIndex.js
+++ b/src/core/imports/HandlersIndex.js
@@ -1,0 +1,29 @@
+import ChatConnectionHandler from "~/src/handlers/ChatConnectionHandler.js"
+import ChatControllerHandler from "~/src/handlers/ChatControllerHandler.js"
+import DoneHandler from "~/src/handlers/DoneHandler.js"
+import DuplicateHandler from "~/src/handlers/DuplicateHandler.js"
+import IdleConnectionHandler from "~/src/handlers/IdleConnectionHandler.js"
+import KissTransferGiftHandler from "~/src/handlers/KissTransferGiftHandler.js"
+import LoginErrorHandler from "~/src/handlers/LoginErrorHandler.js"
+import LogoutHandler from "~/src/handlers/LogoutHandler.js"
+import MessageHandler from "~/src/handlers/MessageHandler.js"
+import PrivateMessageHandler from "~/src/handlers/PrivateMessageHandler.js"
+import TickleHandler from "~/src/handlers/TickleHandler.js"
+import UserJoinedHandler from "~/src/handlers/UserJoinedHandler.js"
+import UserLeftHandler from "~/src/handlers/UserLeftHandler.js"
+
+export default [
+    ChatConnectionHandler,
+    ChatControllerHandler,
+    DoneHandler,
+    DuplicateHandler,
+    IdleConnectionHandler,
+    KissTransferGiftHandler,
+    LoginErrorHandler,
+    LogoutHandler,
+    MessageHandler,
+    PrivateMessageHandler,
+    TickleHandler,
+    UserJoinedHandler,
+    UserLeftHandler
+]


### PR DESCRIPTION
This is not ideal. More like adding a bundler like Vite and using `import.meta.glob`